### PR TITLE
Change bases to resources

### DIFF
--- a/overlay/3-node/kustomization.yaml
+++ b/overlay/3-node/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: blazer-cars-lab
 # namePrefix: blazer-cars-lab-
 
-bases:
-  - ../../base/3-node
+resources:
+  - github.com/redhat-partner-solutions/vse-ocp-bases/base/3-node?ref=main
 
 patchesStrategicMerge:
   - ./patches/nmstate-config.yaml

--- a/overlay/sno/kustomization.yaml
+++ b/overlay/sno/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 namespace: rna4
 
-bases:
+resources:
   - ../../base/sno
 
 patchesStrategicMerge:


### PR DESCRIPTION
- Change `bases` to `resources` since `bases` is deprecated
- Change base path to use URL instead of a relative path