### PR TITLE
make bases less blazer-like

### DIFF
--- a/base/3-node/aci.yaml
+++ b/base/3-node/aci.yaml
@@ -10,33 +10,5 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  apiVIP: 10.50.56.98
-  #apiVIP: fd00:6:6:2056::98
-  ingressVIP: 10.50.56.99
-  #ingressVIP: fd00:6:6:2056::99
-  clusterDeploymentRef:
-    name: cluster-name
-  imageSetRef:
-    name: openshift-v4.10.16
-#  manifestsConfigMapRef:
-#    name: cm-overrides-blazer-cars-lab
-  networking:
-    clusterNetwork:
-      - cidr: 10.128.0.0/14
-        hostPrefix: 23
-      - cidr: fd01::/48
-        hostPrefix: 64
-    serviceNetwork:
-      - 172.30.0.0/16
-      - fd02::/112
-    machineNetwork:
-      - cidr: 10.50.56.0/24
-      - cidr: fd00:6:6:2056::0/64
   provisionRequirements:
     controlPlaneAgents: 3
-#  proxy:
-#    httpProxy: http://infra-registry.infra.cars.lab:3128
-#    httpsProxy: http://infra-registry.infra.cars.lab:3128
-#    noProxy: .cars.lab
-  # yamllint disable-line rule:line-length
-  sshPublicKey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFC9CIV1mjDw9VRgfDyPJUNm1BAzjK7xD6JdZeYydYFIbqEN0t+iFK0pEcaj83wuU2HBvd32IHfYJYuHxzkXun2t1h5SPKmyIzQEFGhxWEWDqhzYefHuNU94adpk82qsHssDxNVhDPSZFIc6L/6K3YQyBmeHkC5Pq+NYIk0M+VOGgWXIob+yH8A3mIdN3e3GWPdUIJqFS40BVqfsZIUuUHv9RHYqrCjoJKDlbTO5kFcr5esAyjPX9P7uPCgGgQ4Omtol4G4nzYsti3IpT5dC4IigWkFqb4qwYevn+dkIB7Ju/X43iyylku9ftBf0SkUCylwZJ0JjGmh5avZBAJJS3DTPWQDualOekiD1edlN+b0RQq02iPv945KEh3KDPjf0DSb2GTr0+8GuVWOAzT0slUNV70mmEKkBsk84TD4TPVcSD5E7iogEA6HGaXIY7ab2D2qDpGGnf8u9N4taxpXm4ZmOOBnz4dVMtF6fvzUPfzP9rChVVc8dRFtIW1yARTBtML2yww12XRbsOvq6vAVWJHLfWLycNWbWy8ZSs080/a1auymyWrqfYYO62CYtpNIIO95WpVzl2itL6NZvG9d8VGtjEN6MsSlKy/Lx4x+zS0N3MFVKorZ464zz48oCe8za0hLW5yp5PkudEtVhk1GXq4KrrqNk+A/Ofhdre8H6N9Ew=='

--- a/base/3-node/kustomization.yaml
+++ b/base/3-node/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - pullsecret-sealed.yaml
+  - provisioning.yaml
   - aci.yaml
   - clusterdeployment.yaml
   - infraenv.yaml

--- a/base/3-node/managedcluster.yaml
+++ b/base/3-node/managedcluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cluster
   namespace: clustername
   labels:
-    local-argo: True
+    local-argo: "True"
     cluster.open-cluster-management.io/clusterset: all-openshift-clusters
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/base/3-node/provisioning.yaml
+++ b/base/3-node/provisioning.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  name: provisioning-configuration
+spec:
+  provisioningNetwork: Disabled
+  disableVirtualMediaTLS: false
+  watchAllNamespaces: true


### PR DESCRIPTION
When trying to integrate the deployment of volante with 3-node I hit a few issues. Goal was to make bases less blazer-like:

- Proposal of a new AgentClusterInstall base
- Fix the default for provisioning object (similar to what we do with SNO)
- 'local-argo' is a string