### PR TITLE
sno AgentClusterInstall and InfraEnvironment updates

### DIFF
--- a/base/sno/aci.yaml
+++ b/base/sno/aci.yaml
@@ -5,25 +5,10 @@ metadata:
   name: cluster
   namespace: cluster-name
   annotations:
-# yamllint disable-line rule:line-length
+    # yamllint disable-line rule:line-length
     agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"OVNKubernetes"}}'
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  clusterDeploymentRef:
-    name: cluster-name
-  imageSetRef:
-    name: openshift-v4.10.16
-  networking:
-    clusterNetwork:
-      - cidr: 10.128.0.0/14
-        hostPrefix: 23
-    serviceNetwork:
-      - 172.30.0.0/16
-    machineNetwork:
-      - cidr: 10.19.6.0/24
   provisionRequirements:
     controlPlaneAgents: 1
-    workerAgents: 0
-# yamllint disable-line rule:line-length
-  sshPublicKey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDzcf7gr7S7jVWKJr1/NsLvTBR/JNmqpWwygq/v4rP+QObIZME5EmYNYw4jwGk/anDxFff3XcPVKYjNarv7xULn3F+yOmZxZbmFrXTZC+iWArGD56W79CTaCxPsZies32/BitoLZwqPZf6lsBKaMB0LOdlrKfZFP7x6e/PR9or+1+1PWHfP3QJmJNfLjMzFxrUM/UBkMR8knL8dFsAkvOTfdRm/X56enMlmqzqN5kWhSYwhj7YCwssUNMF+qWVYaggKyRbxFcSv3ytit4Ygw4HRPfSNiyBHxFv2EmSmXCiawv1JidHVIrfFjqHRh/dtBlMAF3Bwd7pYoQ8ELvpIoRXZ02pFab1pmNO/KXFn7F8RW2wZYmTa+YLrXPQrC087R50Mto/cWhwaRuXqtnAgMfO78hxo8lwqbDwfcbSOr8D9mYM5FVJ+cH4LDDwFzuICFh3kp82ALF44ZzOpcsXVY4P4wPzXqda4lQjwx4sN6/ZDZcFnrad48+PXp/wEWTMfPbM= core@metal3'

--- a/overlay/sno/kustomization.yaml
+++ b/overlay/sno/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 
 patchesStrategicMerge:
   - ./patches/nmstate-config.yaml
+  - ./patches/aci.yaml
 
 patches:
   - target:
@@ -32,6 +33,15 @@ patches:
         path: /metadata/name
         value: 'rna4-bmc-secret'
   - target:
+      kind: AgentClusterInstall
+    patch: |-
+      - op: replace
+        path: /spec/clusterDeploymentRef/name
+        value: 'rna4'
+      - op: replace
+        path: /metadata/name
+        value: 'rna4'
+  - target:
       kind: ManagedCluster
     patch: |-
       - op: replace
@@ -53,6 +63,3 @@ patches:
   - target:
       kind: KlusterletAddonConfig
     path: ./patches/klusterletaddon-patch.yaml
-  - target:
-      kind: AgentClusterInstall
-    path: ./patches/aci.yaml

--- a/overlay/sno/patches/aci.yaml
+++ b/overlay/sno/patches/aci.yaml
@@ -1,10 +1,26 @@
-- op: replace
-  path: /spec/clusterDeploymentRef/name
-  value: 'rna4'
-- op: replace
-  path: /metadata/name
-  value: 'rna4'
-- op: replace
-  path: /spec/sshPublicKey
-# yamllint disable-line rule:line-length
-  value: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCqKXhabF5eesISHsAS/7BSQFKuXgQRgV2Q7zU0u1/8lJF3hsNKcdCehb41nUrIGT00yIWlCl+5vkihR8CwST0iotT/aig6jVXCQ1I67v1GXQ+qZDF7yhoHDu8m2ctIm9NATG39y6lMQgvw5gjDlrKIwTdvEOH+OYmAiheV262cb9xJ1BhBm6Mp4c5Ra6VMYjmXrWH3ADo0w8PkO8VgbsxyVBSUbJpsqbqv3YmFYUqqjjUtrlGb7iXutV779rRBWqH4MfHX2Y4KmRmPb1teIWVuS7FlrcHvrfVZwafvypfUS5Avrj6rolUCCFKm+47McLZ4HVAEkTc6GonU0pb19I7WZWHuwyb61NIMlRU1tZcwhrVH5SAhim19ylxMt4vpdJp0B5/EywSfgrzsCKOTir+9lgWsanS+MZbHAWrV9WqCIslbUFE7s72d6fzt2hYQM9JxFrBwnL91y0q8f1SZV1e4pm6oqQq1gkB3ndn2MrxFMBQKmqy65E7XLZu6PJiuIgM= core@metal3'
+---
+apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
+metadata:
+  name: cluster
+  namespace: cluster-name
+spec:
+  clusterDeploymentRef:
+    name: rna4
+  imageSetRef:
+    name: openshift-v4.10.16
+  # dual stack network config
+  networking:
+    clusterNetwork:
+      - cidr: 10.128.0.0/14
+        hostPrefix: 23
+      - cidr: fd01::/48
+        hostPrefix: 64
+    serviceNetwork:
+      - 172.30.0.0/16
+      - fd02::/112
+    machineNetwork:
+      - cidr: 172.17.0.0/24
+      - cidr: fd00:6:6:2060::0/64
+  # yamllint disable-line rule:line-length
+  sshPublicKey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDzcf7gr7S7jVWKJr1/NsLvTBR/JNmqpWwygq/v4rP+QObIZME5EmYNYw4jwGk/anDxFff3XcPVKYjNarv7xULn3F+yOmZxZbmFrXTZC+iWArGD56W79CTaCxPsZies32/BitoLZwqPZf6lsBKaMB0LOdlrKfZFP7x6e/PR9or+1+1PWHfP3QJmJNfLjMzFxrUM/UBkMR8knL8dFsAkvOTfdRm/X56enMlmqzqN5kWhSYwhj7YCwssUNMF+qWVYaggKyRbxFcSv3ytit4Ygw4HRPfSNiyBHxFv2EmSmXCiawv1JidHVIrfFjqHRh/dtBlMAF3Bwd7pYoQ8ELvpIoRXZ02pFab1pmNO/KXFn7F8RW2wZYmTa+YLrXPQrC087R50Mto/cWhwaRuXqtnAgMfO78hxo8lwqbDwfcbSOr8D9mYM5FVJ+cH4LDDwFzuICFh3kp82ALF44ZzOpcsXVY4P4wPzXqda4lQjwx4sN6/ZDZcFnrad48+PXp/wEWTMfPbM= core@metal3'

--- a/overlay/sno/patches/infraenv-patch.yaml
+++ b/overlay/sno/patches/infraenv-patch.yaml
@@ -4,6 +4,10 @@
 - op: replace
   path: /spec/baseDomain
   value: 'cloud.lab.eng.bos.redhat.com'
+# IPv4/IPv6 NTP
+- op: replace
+  path: /spec/additionalNTPSources
+  value: ['10.18.100.10', 'fd00:6:6:11::52']
 - op: replace
   path: /spec/clusterRef/namespace
   value: 'rna4'


### PR DESCRIPTION
- Generalized AgentClusterInstall and patched  using patchesstrategicMerge.
-  Added in overlay AgentclusterInstall example of configuring dual IPv4/IPv6 networking stack 
- Added dual stack example for NTP sources in patched Infraenv